### PR TITLE
feature(navbar): Unlock listing endpoint to display org counts #342

### DIFF
--- a/grails-app/providers/marketplace/rest/writer/FilteredListingsCountsRepresentationWriter.groovy
+++ b/grails-app/providers/marketplace/rest/writer/FilteredListingsCountsRepresentationWriter.groovy
@@ -1,0 +1,27 @@
+package marketplace.rest.writer
+
+import org.codehaus.groovy.grails.commons.GrailsApplication
+
+import org.springframework.beans.factory.annotation.Autowired
+
+import marketplace.FilteredListings
+import marketplace.hal.AbstractRepresentationWriter
+
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.ext.Provider
+
+import marketplace.rest.representation.out.FilteredListingsCountsRepresentation
+
+@Provider
+@Produces([
+    MediaType.APPLICATION_JSON
+])
+class FilteredListingsCountsRepresentationWriter extends AbstractRepresentationWriter<FilteredListings.Counts> {
+
+    @Autowired
+    FilteredListingsCountsRepresentationWriter(GrailsApplication grailsApplication,
+            FilteredListingsCountsRepresentation.Factory factory) {
+        super(grailsApplication, factory)
+    }
+}

--- a/grails-app/resources/marketplace/rest/resource/ListingResource.groovy
+++ b/grails-app/resources/marketplace/rest/resource/ListingResource.groovy
@@ -28,6 +28,8 @@ import marketplace.ItemComment
 import marketplace.ListingActivity
 import marketplace.ApprovalStatus
 
+import marketplace.FilteredListings
+
 import marketplace.rest.RequiredListingCollection
 import marketplace.rest.RequiringListingCollection
 
@@ -235,4 +237,12 @@ class ListingResource extends RepresentationResource<Listing, ListingInputRepres
     public SearchResult<Listing> search(@Context UriInfo uriInfo) {
         listingSearchService.searchListings(SearchCriteria.fromQueryParams(uriInfo.getQueryParameters(true)))
     }
+
+    @Path('/counts')
+    @GET
+    @Produces([MediaType.APPLICATION_JSON])
+    public FilteredListings.Counts getListingCount() {
+        service.getAllCounts()
+    }
+
 }

--- a/src/groovy/marketplace/rest/representation/out/FilteredListingsCountsRepresentation.groovy
+++ b/src/groovy/marketplace/rest/representation/out/FilteredListingsCountsRepresentation.groovy
@@ -1,0 +1,34 @@
+package marketplace.rest.representation.out
+
+import org.springframework.stereotype.Component
+
+import marketplace.hal.ApplicationRootUriBuilderHolder
+import marketplace.hal.AbstractHalRepresentation
+import marketplace.hal.RepresentationFactory
+
+import marketplace.FilteredListings
+
+class FilteredListingsCountsRepresentation extends AbstractHalRepresentation<FilteredListings.Counts> {
+    private FilteredListings.Counts counts
+
+    private FilteredListingsCountsRepresentation(FilteredListings.Counts counts) {
+        this.counts = counts
+    }
+
+    public int getApproved() { counts.approved }
+    public int getEnabled() { counts.enabled }
+    public Map<String, Integer> getAgencyCounts() {
+            return counts.agencyCounts.inject([:]) { acc, k, v ->
+                k ? acc + [new AbstractMap.SimpleEntry(k.toString(), v)] : acc
+            }
+        }
+
+    @Component
+    public static class Factory implements RepresentationFactory<FilteredListings.Counts> {
+        AbstractHalRepresentation<FilteredListings.Counts> toRepresentation(
+                FilteredListings.Counts counts,
+                ApplicationRootUriBuilderHolder uriBuilderHolder) {
+            new FilteredListingsCountsRepresentation(counts)
+        }
+    }
+}

--- a/src/groovy/marketplace/rest/service/ListingRestService.groovy
+++ b/src/groovy/marketplace/rest/service/ListingRestService.groovy
@@ -163,7 +163,6 @@ class ListingRestService extends RestService<Listing> {
      * null to match all listings
      */
     @Override
-    @RolesAllowed(['ROLE_ADMIN', 'ROLE_ORG_STEWARD'])
     public FilteredListings getAllMatchingParams(
             InputRepresentation<Agency> org,
             ApprovalStatus approvalStatus,

--- a/src/groovy/marketplace/rest/service/ListingRestService.groovy
+++ b/src/groovy/marketplace/rest/service/ListingRestService.groovy
@@ -163,6 +163,7 @@ class ListingRestService extends RestService<Listing> {
      * null to match all listings
      */
     @Override
+    @RolesAllowed(['ROLE_ADMIN', 'ROLE_ORG_STEWARD'])
     public FilteredListings getAllMatchingParams(
             InputRepresentation<Agency> org,
             ApprovalStatus approvalStatus,
@@ -203,6 +204,15 @@ class ListingRestService extends RestService<Listing> {
             approvalStatus, enabled)
 
         return new FilteredListings(filteredListings, counts)
+    }
+
+    private FilteredListings.Counts getAllCounts() {
+        ApprovalStatus approvalStatus = ApprovalStatus.APPROVED
+        Boolean enabled = true
+        Collection<Agency> agencies = null
+        FilteredListings.Counts counts = getCountsMatchingParams(agencies,
+            approvalStatus, enabled)
+        return counts
     }
 
     /**


### PR DESCRIPTION
This is so that users can see organization counts in the Organizations pull down.